### PR TITLE
Replace closure style API to improve DX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "sentry-rust-minidump"
 readme = "README.md"
 repository = "https://github.com/timfish/sentry-rust-minidump"
-version = "0.1.3"
+version = "0.2.0"
 
 [dependencies]
 crash-handler = "0.3"

--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@ your application code.
 ```toml
 [dependencies]
 sentry = "0.27"
-sentry-rust-minidump = "0.1"
+sentry-rust-minidump = "0.2"
 ```
 
 ```rust
 fn main() {
     let client = sentry::init(("__DSN__", sentry::ClientOptions {
         release: sentry::release_name!(),
-        debug: true,
         ..Default::default()
     }));
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 Experimental code that wraps the `minidumper` and `crash-handler` crates to make it simpler to capture
 and send minidumps from a separate process via Sentry Rust.
 
-`sentry_rust_minidump::init` starts the current executable with an argument that
+`sentry_rust_minidump::init` starts the current executable again with an argument that
 causes it to start in crash reporter mode. In this mode it waits for minidump
-notification from the main process and handles writing and sending of the
+notification from the main app process and handles writing and sending of the
 minidump file as an attachment to Sentry.
 
-The first closure is called in both the main and crash reporter processes and is used to configure
-and start Sentry. The second closure is only called in the main process to run the
-application code.
+Everything before `sentry_rust_minidump::init` is called in both the main and
+crash reporter processes and should configure and start Sentry. Everything
+after `sentry_rust_minidump::init` is only called in the main process to run
+your application code.
 
 ```toml
 [dependencies]
@@ -30,8 +31,9 @@ fn main() {
     let _guard = sentry_rust_minidump::init(&client);
     // Everything after here runs in only the app process
 
-    std::thread::sleep(std::time::Duration::from_secs(2));
+    App::run();
 
+    // This will cause a minidump to be sent to Sentry 
     #[allow(deref_nullptr)]
     unsafe {
         *std::ptr::null_mut() = true;

--- a/examples/app.rs
+++ b/examples/app.rs
@@ -1,25 +1,21 @@
 fn main() {
-    sentry_rust_minidump::init(
-        sentry::release_name!(),
-        |_| {
-            // This code will run in both processes and setup sentry
-            sentry::init((
-                "https://233a45e5efe34c47a3536797ce15dafa@o447951.ingest.sentry.io/5650507",
-                sentry::ClientOptions {
-                    release: sentry::release_name!(),
-                    debug: true,
-                    ..Default::default()
-                },
-            ))
+    let client = sentry::init((
+        "https://233a45e5efe34c47a3536797ce15dafa@o447951.ingest.sentry.io/5650507",
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            debug: true,
+            ..Default::default()
         },
-        || {
-            // This code only runs in the main app process
-            std::thread::sleep(std::time::Duration::from_secs(2));
+    ));
 
-            #[allow(deref_nullptr)]
-            unsafe {
-                *std::ptr::null_mut() = true;
-            }
-        },
-    );
+    // Everything before here runs in both app and crash reporter processes
+    let _guard = sentry_rust_minidump::init(&client);
+    // Everything after here runs in only the app process
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    #[allow(deref_nullptr)]
+    unsafe {
+        *std::ptr::null_mut() = true;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,25 +8,21 @@ pub fn is_crash_reporter_process() -> bool {
 }
 
 #[must_use = "The return value of init should not be dropped until the program exits"]
-pub fn init(client: &sentry::Client) -> Option<client::ClientHandle> {
-    let release = client
+pub fn init(sentry_client: &sentry::Client) -> Option<client::ClientHandle> {
+    let release = sentry_client
         .options()
         .release
         .as_ref()
         .map(|r| r.to_string())
         .expect("A release must be set in sentry::ClientOptions");
 
-    let crash_reporter_arg = std::env::args()
-        .find(|arg| arg.starts_with(CRASH_REPORTER_ARG))
-        .and_then(|arg| arg.split('=').last().map(|arg| arg.to_string()));
-
-    if let Some(crash_reporter_arg) = crash_reporter_arg {
-        server::start(&release, &crash_reporter_arg);
+    if is_crash_reporter_process() {
+        server::start(&release);
         // The server has exited which means the main app process has crashed or
         // exited.
         // Because we're going to force-exit, we need to flush to ensure any
         // events are sent.
-        client.flush(Some(std::time::Duration::from_secs(5)));
+        sentry_client.flush(Some(std::time::Duration::from_secs(5)));
         // We have to force exit so that the app code after here does not run in
         // the crash reporter process.
         std::process::exit(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,10 @@
 mod client;
 mod server;
 
-const CRASH_REPORTER_ARG: &str = "--start-crash-reporter-server";
-
-fn get_release_fallback() -> Option<String> {
-    std::env::current_exe().ok().and_then(|current_exe| {
-        current_exe
-            .file_name()
-            .map(|file_name| file_name.to_string_lossy().to_string())
-    })
-}
-
-pub(crate) fn socket_from_release(release: &str) -> String {
-    release
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect()
-}
+const CRASH_REPORTER_ARG: &str = "--crash-reporter-server";
 
 pub fn is_crash_reporter_process() -> bool {
-    std::env::args().any(|arg| arg == CRASH_REPORTER_ARG)
+    std::env::args().any(|arg| arg.starts_with(CRASH_REPORTER_ARG))
 }
 
 #[must_use = "The return value of init should not be dropped until the program exits"]
@@ -29,22 +14,23 @@ pub fn init(client: &sentry::Client) -> Option<client::ClientHandle> {
         .release
         .as_ref()
         .map(|r| r.to_string())
-        .or_else(get_release_fallback)
         .expect("A release must be set in sentry::ClientOptions");
 
-    if is_crash_reporter_process() {
-        server::start(&release);
+    let crash_reporter_arg = std::env::args()
+        .find(|arg| arg.starts_with(CRASH_REPORTER_ARG))
+        .and_then(|arg| arg.split('=').last().map(|arg| arg.to_string()));
+
+    if let Some(crash_reporter_arg) = crash_reporter_arg {
+        server::start(&release, &crash_reporter_arg);
+        // The server has exited which means the main app process has crashed or
+        // exited.
+        // Because we're going to force-exit, we need to flush to ensure any
+        // events are sent.
         client.flush(Some(std::time::Duration::from_secs(5)));
         // We have to force exit so that the app code after here does not run in
         // the crash reporter process.
         std::process::exit(0);
     } else {
-        match client::start(&release) {
-            Ok(handler) => Some(handler),
-            Err(e) => {
-                sentry::capture_error(&e);
-                None
-            }
-        }
+        client::start(&release).ok()
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use crate::socket_from_release;
 use minidumper::{LoopAction, MinidumpBinary, Server, ServerHandler};
 use sentry::{
-    protocol::{Attachment, Event, Value},
+    protocol::{Attachment, AttachmentType, Event, Value},
     Level,
 };
 use std::{
@@ -19,6 +19,7 @@ fn attachment_from_minidump(minidump: MinidumpBinary) -> (Option<Attachment>, Pa
             Attachment {
                 buffer,
                 filename: name.to_string_lossy().to_string(),
+                ty: Some(AttachmentType::Minidump),
                 ..Default::default()
             }
         })


### PR DESCRIPTION
Before:
```rust
fn main() {
    sentry_rust_minidump::init(
        sentry::release_name!(),
        |is_crash_reporter_process| {
            // This code will be run early in both processes to setup sentry
            sentry::init((
                "__DSN__",
                sentry::ClientOptions {
                    release: sentry::release_name!(),
                    ..Default::default()
                },
            )) // You must return the guard!
        },
        || {
            // Run your app or whatever you were planning to do...
            app::run();
            // This will cause a minidump to be sent to Sentry
            unsafe {
                *std::ptr::null_mut() = true;
            }
        },
    );
}
```
After:
```rust
fn main() {
    let client = sentry::init(("__DSN__", sentry::ClientOptions {
        release: sentry::release_name!(),
        ..Default::default()
    }));

    // Everything before here runs in both app and crash reporter processes
    let _guard = sentry_rust_minidump::init(&client);
    // Everything after here runs only in the app process

    // Run your app or whatever you were planning to do...
    app::run();

    // This will cause a minidump to be sent to Sentry
    unsafe {
        *std::ptr::null_mut() = true;
    }
}
```