### PR TITLE
bumped sentry to 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.11.0"
 
 [dependencies]
 minidumper-child = "0.2"
-sentry = "0.37"
+sentry = "0.38"
 thiserror = "2"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }


### PR DESCRIPTION
`sentry` has updated on crates.io, so this is just a simple bump.